### PR TITLE
Do not blow up on connection errors

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -62,11 +62,14 @@ export default class {
         .send(options.send)
         .end((err, response) => {
           if (err) {
-            let errorString = JSON.parse(err.response.text).err;
-            return reject({
-              code: err.response.status,
-              text: errorString,
-            });
+            if (err.response) {
+              let errorString = JSON.parse(err.response.text).err;
+              err = {
+                code: err.response.status,
+                text: errorString,
+              }
+            }
+            return reject(err);
           }
 
           resolve(response.body);

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -25,6 +25,22 @@ describe('Connection', () => {
     });
   });
 
+  context('connection error handling', () => {
+    let connection;
+
+    before(() => nock.disableNetConnect());
+    after(() => nock.enableNetConnect());
+    beforeEach(() => {
+      connection = new Connection(defaultOptions);
+    });
+
+    it('rejects with connection error if habit is unreachable', () => {
+      let request = connection.get('user');
+
+      return expect(request).to.be.rejectedWith(/Nock: Not allow net connect/);
+    });
+  });
+
   describe('#getUuid', () => {
     it('returns uuid', () => {
       let connection = new Connection(defaultOptions);


### PR DESCRIPTION
Errors that stem from non-request related failures (e.g. connection issues) do not have a `response` property. Previously we would blow up when trying to parse these errors.

I ran into this issue trying to reach out to habit when my internet connection dropped, so I think this is relevant. 

I could not find a way to raise the `ENOTFOUND` error via nock, so I used `nock.disableNetConnect` instead.  The error that Nock throws when mocking all http requests is similar in shape (e.g a flat object without a `response` property. Let me know if there's a better way :tm: 

Given the following code:

```
habitica.task.score(
  'test',
  'up'
).then(function () {
  console.log('Successs');
}).catch(function (err) {
  console.log(err);
});
```

Behavior before: 

![screen shot 2015-10-28 at 6 17 32 pm](https://cloud.githubusercontent.com/assets/1290336/10806910/0e97b36c-7da8-11e5-8bf5-0bda4b4d8f85.png)

Behavior after:
![screen shot 2015-10-28 at 11 07 50 am](https://cloud.githubusercontent.com/assets/1290336/10806856/4f9fd9bc-7da7-11e5-9d5b-09b69ca3da24.png)
