### PR TITLE
API-support for tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Account from './account';
 import Content from './content';
 import Task from './task';
 import User from './user';
+import Tag from './tag';
 
 export default class {
   constructor (options = {}) {
@@ -53,6 +54,10 @@ export default class {
     this.user = new User({
       connection: this._connection,
     });
+    
+    this.tag = new Tag({
+      connection: this._connection,
+    })
   }
 
 

--- a/src/tag.js
+++ b/src/tag.js
@@ -1,0 +1,124 @@
+// Tag
+// tags
+// Sort thy stuff!
+export default class {
+  constructor (option) {
+    this._connection = options.connection;
+    
+    this.delete = this.del;
+  }
+  
+  // # tag.get()
+  // Get your tags.
+  //
+  // If no arguments are passed in, all the tags are returned.
+  //
+  // ```js
+  // api.tag.get()
+  //   .then((tags) => {
+  //     tags[0]; // one of your tasks
+  //   });
+  // ```
+  //
+  // If you pass in a tag id, it will get that specific tag.
+  //
+  // ```js
+  // api.tag.get('id-of-your-tag')
+  //   .then((tag) => {
+  //     tag.name; // the tag name
+  //     tag.id; // the tag id
+  //   });
+  // ```
+  get (id) {
+    let url = 'user/tags';
+    
+    if (id) {
+      url += '/${id}';
+    }
+    
+    return this._connection.get(url)
+      .then((tags) => {
+        return tags;
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+  
+  // # tag.post()
+  // Create a new tag
+  //
+  // Takes the tag object as an argument
+  //
+  // ```js
+  // api.tag.post({
+  //  name: 'tag name',
+  // }).then((tag) => {
+  //   tag.id; // 'tag id'
+  // });
+  // ```
+  post (tagBody) {
+    return this._connection.post(
+        'user/tags',
+        { send: tagBody}
+      ).then((tag) => {
+        return tag;
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+  
+  // # tag.put()
+  // Update an existing tag
+  //
+  // tag id and tag body are required arguments.
+  //
+  // ```js
+  // api.tag.put(
+  //   'tag-id',
+  //   { name: 'new tag name' }
+  // ).then((tag) => {
+  //   tag.name; // 'new tag name'
+  // });
+  // ```
+  put (id, tagBody) {
+    if (!id) throw 'Tag id is required';
+    if (!tagBody) throw 'Tag body is required';
+    
+    return this._connection.put(
+        `user/tags/${id}`,
+        { send: tagBody }
+      ).then((tag) => {
+        return tag;
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+  
+  // # tag.del()
+  // Delete existing tag.
+  //
+  // Tag id is a required argument.
+  //
+  // ```js
+  // api.tag.del(
+  //   'tag-id',
+  // ).then((tag) => {
+  //   tag; // {}
+  // });
+  // ```
+  del (id) {
+    if (!id) throw 'Tag id is required';
+
+    return this._connection.del(`user/tags/${id}`)
+      .then((tag) => {
+        return tag;
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
+  
+}

--- a/src/tag.js
+++ b/src/tag.js
@@ -3,7 +3,7 @@
 // Sort thy stuff!
 export default class {
   constructor (option) {
-    this._connection = options.connection;
+    this._connection = option.connection;
     
     this.delete = this.del;
   }
@@ -33,7 +33,7 @@ export default class {
     let url = 'user/tags';
     
     if (id) {
-      url += '/${id}';
+      url += `/${id}`;
     }
     
     return this._connection.get(url)
@@ -53,8 +53,8 @@ export default class {
   // ```js
   // api.tag.post({
   //  name: 'tag name',
-  // }).then((tag) => {
-  //   tag.id; // 'tag id'
+  // }).then((tags) => {
+  //   tags; // it returns all of the existing tags
   // });
   // ```
   post (tagBody) {
@@ -105,16 +105,16 @@ export default class {
   // ```js
   // api.tag.del(
   //   'tag-id',
-  // ).then((tag) => {
-  //   tag; // {}
+  // ).then((tags) => {
+  //   tags; // remaining existing tags
   // });
   // ```
   del (id) {
     if (!id) throw 'Tag id is required';
 
     return this._connection.del(`user/tags/${id}`)
-      .then((tag) => {
-        return tag;
+      .then((tags) => {
+        return tags;
       })
       .catch((err) => {
         throw err;


### PR DESCRIPTION
Complete API-support for getting, creating, changing and deleting tags. Sadly I was unable to get your tests to run on my machine (most certainly due to my inability) so I skipped creating automatic testing for tag.js. I ended up only testing the new feature manually in my own project, but everything seemed to work smoothly.
